### PR TITLE
Add useControlledState hook

### DIFF
--- a/examples/basic/src/components/use-controlled-state/components/controlled-input.tsx
+++ b/examples/basic/src/components/use-controlled-state/components/controlled-input.tsx
@@ -1,0 +1,32 @@
+import { useControlledState } from "@altalyst/hookify";
+import { useState } from "react";
+
+export const ControlledInput = () => {
+  const [parentValue, setParentValue] = useState("Controlled by parent");
+
+  const [value, setValue] = useControlledState<string>(
+    parentValue,
+    "",
+    setParentValue
+  );
+
+  return (
+    <div>
+      <h2>Controlled Input</h2>
+      <p>The parent component controls the state.</p>
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        placeholder="Type something..."
+      />
+      <p>Current value: {value}</p>
+      <button onClick={() => setParentValue("Reset by parent")}>
+        Parent Reset
+      </button>
+      <button onClick={() => setParentValue((prev) => prev.toUpperCase())}>
+        Parent Uppercase
+      </button>
+    </div>
+  );
+};

--- a/examples/basic/src/components/use-controlled-state/components/counter-with-updater.tsx
+++ b/examples/basic/src/components/use-controlled-state/components/counter-with-updater.tsx
@@ -1,0 +1,27 @@
+import { useControlledState } from "@altalyst/hookify";
+
+export const CounterWithUpdater = () => {
+  const [count, setCount] = useControlledState<number>(
+    undefined,
+    0,
+    (newValue: number) => console.log("Count changed to:", newValue)
+  );
+
+  return (
+    <div>
+      <h2>Counter with Updater Function</h2>
+      <p>Demonstrates using updater functions like setState.</p>
+      <p>Count: {count}</p>
+      <button onClick={() => setCount((prev: number) => prev + 1)}>
+        Increment
+      </button>
+      <button onClick={() => setCount((prev: number) => prev - 1)}>
+        Decrement
+      </button>
+      <button onClick={() => setCount((prev: number) => prev * 2)}>
+        Double
+      </button>
+      <button onClick={() => setCount(0)}>Reset</button>
+    </div>
+  );
+};

--- a/examples/basic/src/components/use-controlled-state/components/custom-select.tsx
+++ b/examples/basic/src/components/use-controlled-state/components/custom-select.tsx
@@ -1,0 +1,75 @@
+import { useControlledState } from "@altalyst/hookify";
+import { useState } from "react";
+
+interface CustomSelectProps {
+  value?: string;
+  defaultValue?: string;
+  onChange?: (value: string) => void;
+  options: string[];
+}
+
+const CustomSelect = ({
+  value,
+  defaultValue = "",
+  onChange,
+  options,
+}: CustomSelectProps) => {
+  const [selectedValue, setSelectedValue] = useControlledState(
+    value,
+    defaultValue,
+    onChange
+  );
+
+  return (
+    <select
+      value={selectedValue}
+      onChange={(e) => setSelectedValue(e.target.value)}
+      style={{ padding: "8px", fontSize: "14px" }}
+    >
+      <option value="">Select an option</option>
+      {options.map((option) => (
+        <option key={option} value={option}>
+          {option}
+        </option>
+      ))}
+    </select>
+  );
+};
+
+export const CustomSelectDemo = () => {
+  const [controlledValue, setControlledValue] = useState("React");
+  const fruits = ["Apple", "Banana", "Orange", "Grape"];
+  const frameworks = ["React", "Vue", "Angular", "Svelte"];
+
+  return (
+    <div>
+      <h2>Reusable Component Pattern</h2>
+      <p>
+        Building a custom select component that works in both controlled and
+        uncontrolled modes.
+      </p>
+
+      <div style={{ marginBottom: "20px" }}>
+        <h3>Uncontrolled Mode</h3>
+        <CustomSelect
+          defaultValue="Banana"
+          options={fruits}
+          onChange={(val) => console.log("Fruit selected:", val)}
+        />
+      </div>
+
+      <div>
+        <h3>Controlled Mode</h3>
+        <CustomSelect
+          value={controlledValue}
+          options={frameworks}
+          onChange={setControlledValue}
+        />
+        <p>Selected framework: {controlledValue}</p>
+        <button onClick={() => setControlledValue("Vue")}>
+          Set to Vue (parent control)
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/examples/basic/src/components/use-controlled-state/components/uncontrolled-input.tsx
+++ b/examples/basic/src/components/use-controlled-state/components/uncontrolled-input.tsx
@@ -1,0 +1,24 @@
+import { useControlledState } from "@altalyst/hookify";
+
+export const UncontrolledInput = () => {
+  const [value, setValue] = useControlledState<string>(
+    undefined,
+    "",
+    (newValue: string) => console.log("Value changed:", newValue)
+  );
+
+  return (
+    <div>
+      <h2>Uncontrolled Input</h2>
+      <p>The component manages its own state internally.</p>
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        placeholder="Type something..."
+      />
+      <p>Current value: {value || "(empty)"}</p>
+      <button onClick={() => setValue("")}>Clear</button>
+    </div>
+  );
+};

--- a/examples/basic/src/components/use-controlled-state/index.tsx
+++ b/examples/basic/src/components/use-controlled-state/index.tsx
@@ -1,0 +1,15 @@
+import { ControlledInput } from "./components/controlled-input";
+import { CounterWithUpdater } from "./components/counter-with-updater";
+import { CustomSelectDemo } from "./components/custom-select";
+import { UncontrolledInput } from "./components/uncontrolled-input";
+
+export const UseControlledState = () => {
+  return (
+    <>
+      <UncontrolledInput />
+      <ControlledInput />
+      <CounterWithUpdater />
+      <CustomSelectDemo />
+    </>
+  );
+};

--- a/examples/basic/src/router.tsx
+++ b/examples/basic/src/router.tsx
@@ -2,6 +2,7 @@ import { createBrowserRouter } from "react-router-dom";
 
 import { HooksPage } from "./routes/hooks.tsx";
 import { UseApiPage } from "./routes/hooks/use-api.tsx";
+import { UseControlledStatePage } from "./routes/hooks/use-controlled-state.tsx";
 import { UseDebouncePage } from "./routes/hooks/use-debounce.tsx";
 import { UseEffectAfterMountPage } from "./routes/hooks/use-effect-after-mount.tsx";
 import { UseMountedPage } from "./routes/hooks/use-mounted.tsx";
@@ -35,6 +36,10 @@ export const router = createBrowserRouter([
       {
         path: "/hooks/use-toggle-state",
         element: <UseToggleStatePage />,
+      },
+      {
+        path: "/hooks/use-controlled-state",
+        element: <UseControlledStatePage />,
       },
       {
         path: "/hooks/use-persisted-state",

--- a/examples/basic/src/routes/hooks.tsx
+++ b/examples/basic/src/routes/hooks.tsx
@@ -21,6 +21,11 @@ export const HooksPage = () => {
             <Link to={"/hooks/use-toggle-state"}>useToggleState hook</Link>
           </li>
           <li>
+            <Link to={"/hooks/use-controlled-state"}>
+              useControlledState hook
+            </Link>
+          </li>
+          <li>
             <Link to={"/hooks/use-persisted-state"}>
               usePersistedState hook
             </Link>

--- a/examples/basic/src/routes/hooks/use-controlled-state.tsx
+++ b/examples/basic/src/routes/hooks/use-controlled-state.tsx
@@ -1,0 +1,10 @@
+import { UseControlledState } from "../../components/use-controlled-state";
+
+export const UseControlledStatePage = () => {
+  return (
+    <>
+      <h1>Demo for: useControlledState hook</h1>
+      <UseControlledState />
+    </>
+  );
+};

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,4 +1,5 @@
 export * from "./use-api";
+export * from "./use-controlled-state";
 export * from "./use-debounce";
 export * from "./use-effect-after-mount";
 export * from "./use-mounted";

--- a/src/hooks/use-controlled-state.ts
+++ b/src/hooks/use-controlled-state.ts
@@ -1,0 +1,167 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { warnInDevelopment } from "../utils";
+
+/**
+ * Props type for components using controlled state pattern.
+ *
+ * @template T - The type of the state value.
+ */
+export type UseControlledStateProps<T> = {
+  /** The controlled value from parent component. When provided, the component operates in controlled mode. */
+  value?: T;
+  /** The initial/default value when in uncontrolled mode. */
+  defaultValue: T;
+  /** Callback invoked when the value changes. */
+  onChange?: (value: T) => void;
+};
+
+/**
+ * Checks if a value indicates controlled mode (not undefined).
+ *
+ * This helper function determines whether a component should operate in controlled mode
+ * by checking if the provided value is defined. In controlled mode, the parent component
+ * manages the state. In uncontrolled mode (when value is undefined), the component
+ * manages its own internal state.
+ *
+ * @param {unknown} value - The value to check for controlled mode indication.
+ * @returns {boolean} True if the value is defined (controlled mode), false if undefined (uncontrolled mode).
+ */
+const isValueControlled = (value: unknown): boolean => value !== undefined;
+
+/**
+ * A custom React hook that implements the controlled/uncontrolled component pattern.
+ *
+ * This hook allows components to work in two modes:
+ * - **Controlled mode**: When `value` is provided, the parent component manages the state
+ * - **Uncontrolled mode**: When `value` is undefined, the hook manages state internally
+ *
+ * This pattern provides flexibility for component consumers, allowing them to choose
+ * between full control of the state or letting the component manage it automatically.
+ *
+ * The `setValue` function is optimized for performance with a stable reference that only
+ * changes when the component switches between controlled/uncontrolled modes or when the
+ * `onChange` callback changes. This prevents unnecessary re-renders in child components.
+ *
+ * In development mode, the hook will warn if a component switches between controlled
+ * and uncontrolled modes, which is considered an anti-pattern and can lead to
+ * unexpected behavior.
+ *
+ * @template T - The type of the state value.
+ * @param {T | undefined} value - The controlled value. When provided, the hook operates in controlled mode.
+ * @param {T | (() => T)} defaultValue - The initial value for uncontrolled mode. Can be a value or lazy initializer function.
+ * @param {(value: T) => void} [onChange] - Optional callback invoked whenever the value changes.
+ * @returns {readonly [T, (newValue: T | ((prev: T) => T)) => void]} A tuple containing the current value and a stable setter function that accepts either a new value or an updater function.
+ *
+ * @example
+ * ```typescript
+ * // Uncontrolled usage - component manages its own state
+ * function UncontrolledInput() {
+ *   const [value, setValue] = useControlledState(undefined, "", console.log);
+ *   return <input value={value} onChange={(e) => setValue(e.target.value)} />;
+ * }
+ * ```
+ *
+ * @example
+ * ```typescript
+ * // Controlled usage - parent manages the state
+ * function ControlledInput({ value, onChange }) {
+ *   const [inputValue, setInputValue] = useControlledState(value, "", onChange);
+ *   return <input value={inputValue} onChange={(e) => setInputValue(e.target.value)} />;
+ * }
+ * ```
+ *
+ * @example
+ * ```typescript
+ * // With updater function for complex state updates
+ * const [count, setCount] = useControlledState(undefined, 0);
+ * setCount(prev => prev + 1);
+ * ```
+ *
+ * @example
+ * ```typescript
+ * // With lazy initialization for expensive defaults
+ * const [data, setData] = useControlledState(
+ *   undefined,
+ *   () => expensiveComputation()
+ * );
+ * ```
+ */
+export const useControlledState = <T>(
+  value: T | undefined,
+  defaultValue: T | (() => T),
+  onChange?: (value: T) => void
+): readonly [T, (newValue: T | ((prev: T) => T)) => void] => {
+  /**
+   * Internal state used when the component is operating in uncontrolled mode.
+   * Initialized with the `defaultValue` and managed internally by the hook.
+   */
+  const [internalValue, setInternalValue] = useState<T>(defaultValue);
+
+  /**
+   * A ref that tracks whether the component was initially in controlled mode.
+   * Used to detect transitions between controlled and uncontrolled modes,
+   * which is an anti-pattern that triggers development warnings.
+   */
+  const wasControlledRef = useRef(isValueControlled(value));
+
+  /**
+   * Determines the current mode based on whether `value` is defined.
+   * True if controlled (value provided), false if uncontrolled (value undefined).
+   */
+  const isControlled = isValueControlled(value);
+
+  /**
+   * The actual current value returned to the component.
+   * In controlled mode, uses the provided `value`.
+   * In uncontrolled mode, uses the internal state.
+   */
+  const currentValue = isControlled ? (value as T) : internalValue;
+
+  /**
+   * A ref that stores the current value to prevent stale closures in the setValue callback.
+   * This ensures that updater functions always have access to the latest value
+   * without requiring `currentValue` to be in the dependency array.
+   */
+  const currentValueRef = useRef(currentValue);
+  currentValueRef.current = currentValue;
+
+  // Warn in development if switching between controlled/uncontrolled modes
+  useEffect(() => {
+    const isControlledNow = isValueControlled(value);
+
+    // Detect and warn about mode switching (anti-pattern)
+    if (wasControlledRef.current !== isControlledNow) {
+      warnInDevelopment(
+        `useControlledState: Component is changing from ${
+          wasControlledRef.current ? "controlled" : "uncontrolled"
+        } to ${isControlledNow ? "controlled" : "uncontrolled"} mode. ` +
+          "This is an anti-pattern and may cause unexpected behavior."
+      );
+    }
+
+    // Update the controlled mode tracking
+    wasControlledRef.current = isControlledNow;
+  }, [value]);
+
+  // Memoized setter function that handles both direct values and updater functions
+  const setValue = useCallback(
+    (newValue: T | ((prev: T) => T)) => {
+      // Resolve updater function to get the actual value (supports prev => prev + 1 pattern)
+      const resolvedValue =
+        typeof newValue === "function"
+          ? (newValue as (prev: T) => T)(currentValueRef.current)
+          : newValue;
+
+      // Update internal state only in uncontrolled mode (controlled mode ignores this)
+      if (!isValueControlled(value)) {
+        setInternalValue(resolvedValue);
+      }
+
+      // Always notify parent of value changes via onChange callback
+      onChange?.(resolvedValue);
+    },
+    [onChange, value]
+  );
+
+  return [currentValue, setValue] as const;
+};

--- a/src/utils/dev-warnings.ts
+++ b/src/utils/dev-warnings.ts
@@ -1,0 +1,71 @@
+/**
+ * Indicates whether the application is running in development mode.
+ *
+ * This constant is used internally to conditionally execute code that should
+ * only run during development, such as logging warnings or performing validations.
+ * In production builds, bundlers like Webpack or Vite will replace
+ * `process.env.NODE_ENV` with `"production"`, allowing dead code elimination
+ * to remove development-only code paths.
+ */
+export const isDevelopment: boolean = process.env.NODE_ENV !== "production";
+
+/**
+ * Logs a warning message to the console in development mode only.
+ *
+ * This utility function is useful for displaying warnings about incorrect usage,
+ * deprecated features, or potential issues that developers should be aware of
+ * during development. In production builds, these warnings are automatically
+ * removed through tree-shaking, resulting in zero runtime cost.
+ *
+ * @param message - The warning message to log.
+ *
+ * @example
+ * ```typescript
+ * if (value === undefined) {
+ *   warnInDevelopment("Value should not be undefined. Using default value instead.");
+ * }
+ * ```
+ *
+ * @example
+ * ```typescript
+ * warnInDevelopment(
+ *   `Component "${componentName}" is changing from controlled to uncontrolled mode.`
+ * );
+ * ```
+ */
+export const warnInDevelopment = (message: string) => {
+  if (isDevelopment) {
+    console.warn(message);
+  }
+};
+
+/**
+ * Logs an error message to the console in development mode only.
+ *
+ * This utility function is useful for displaying error messages about critical
+ * issues or validation failures that developers need to address during development.
+ * Unlike `warnInDevelopment`, this uses `console.error` to indicate a more severe
+ * issue. In production builds, these error logs are automatically removed through
+ * tree-shaking, resulting in zero runtime cost.
+ *
+ * @param message - The error message to log.
+ *
+ * @example
+ * ```typescript
+ * if (!isValidConfig(config)) {
+ *   errorInDevelopment("Invalid configuration detected. Please check your setup.");
+ * }
+ * ```
+ *
+ * @example
+ * ```typescript
+ * errorInDevelopment(
+ *   `Failed to initialize hook: required parameter "callback" is missing.`
+ * );
+ * ```
+ */
+export const errorInDevelopment = (message: string) => {
+  if (isDevelopment) {
+    console.error(message);
+  }
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from "./dev-warnings";

--- a/tests/hooks/use-controlled-state.spec.ts
+++ b/tests/hooks/use-controlled-state.spec.ts
@@ -1,0 +1,301 @@
+import { useControlledState } from "@/hooks";
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("useControlledState", () => {
+  const originalEnv = process.env.NODE_ENV;
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalEnv;
+    vi.restoreAllMocks();
+  });
+
+  describe("Uncontrolled Mode", () => {
+    it("should use defaultValue as initial value", () => {
+      const { result } = renderHook(() =>
+        useControlledState<string>(undefined, "initial", undefined)
+      );
+
+      expect(result.current[0]).toBe("initial");
+    });
+
+    it("should update internal state when setValue is called", () => {
+      const { result } = renderHook(() =>
+        useControlledState<string>(undefined, "initial", undefined)
+      );
+
+      act(() => {
+        result.current[1]("updated");
+      });
+
+      expect(result.current[0]).toBe("updated");
+    });
+
+    it("should call onChange callback when value changes", () => {
+      const onChange = vi.fn();
+      const { result } = renderHook(() =>
+        useControlledState<string>(undefined, "initial", onChange)
+      );
+
+      act(() => {
+        result.current[1]("updated");
+      });
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith("updated");
+    });
+
+    it("should support lazy initialization", () => {
+      const lazyInit = vi.fn(() => "lazy-value");
+      const { result } = renderHook(() =>
+        useControlledState<string>(undefined, lazyInit, undefined)
+      );
+
+      expect(lazyInit).toHaveBeenCalledTimes(1);
+      expect(result.current[0]).toBe("lazy-value");
+    });
+
+    it("should support updater function", () => {
+      const { result } = renderHook(() =>
+        useControlledState<number>(undefined, 0, undefined)
+      );
+
+      act(() => {
+        result.current[1]((prev) => prev + 1);
+      });
+
+      expect(result.current[0]).toBe(1);
+
+      act(() => {
+        result.current[1]((prev) => prev + 5);
+      });
+
+      expect(result.current[0]).toBe(6);
+    });
+
+    it("should work with complex types", () => {
+      type User = { name: string; age: number };
+      const defaultUser: User = { name: "John", age: 30 };
+
+      const { result } = renderHook(() =>
+        useControlledState<User>(undefined, defaultUser, undefined)
+      );
+
+      expect(result.current[0]).toEqual(defaultUser);
+
+      act(() => {
+        result.current[1]({ name: "Jane", age: 25 });
+      });
+
+      expect(result.current[0]).toEqual({ name: "Jane", age: 25 });
+    });
+  });
+
+  describe("Controlled Mode", () => {
+    it("should use controlled value when provided", () => {
+      const { result } = renderHook(() =>
+        useControlledState<string>("controlled", "default", undefined)
+      );
+
+      expect(result.current[0]).toBe("controlled");
+    });
+
+    it("should not update internal state when setValue is called", () => {
+      const onChange = vi.fn();
+      const { result, rerender } = renderHook(
+        ({ value }) => useControlledState(value, "default", onChange),
+        { initialProps: { value: "controlled" as string | undefined } }
+      );
+
+      act(() => {
+        result.current[1]("attempted-update");
+      });
+
+      // Value should still be controlled value
+      expect(result.current[0]).toBe("controlled");
+      // onChange should still be called
+      expect(onChange).toHaveBeenCalledWith("attempted-update");
+
+      // Value only changes when parent updates it
+      rerender({ value: "new-controlled" });
+      expect(result.current[0]).toBe("new-controlled");
+    });
+
+    it("should update when controlled value changes", () => {
+      const { result, rerender } = renderHook(
+        ({ value }) => useControlledState<string>(value, "default", undefined),
+        { initialProps: { value: "first" as string | undefined } }
+      );
+
+      expect(result.current[0]).toBe("first");
+
+      rerender({ value: "second" });
+      expect(result.current[0]).toBe("second");
+
+      rerender({ value: "third" });
+      expect(result.current[0]).toBe("third");
+    });
+
+    it("should support updater function in controlled mode", () => {
+      const onChange = vi.fn();
+      const { result } = renderHook(() =>
+        useControlledState<number>(10, 0, onChange)
+      );
+
+      act(() => {
+        result.current[1]((prev) => prev + 5);
+      });
+
+      // onChange called with updated value
+      expect(onChange).toHaveBeenCalledWith(15);
+      // But displayed value is still controlled value
+      expect(result.current[0]).toBe(10);
+    });
+  });
+
+  describe("Performance", () => {
+    it("should recreate setValue when onChange changes", () => {
+      const onChange1 = vi.fn();
+      const onChange2 = vi.fn();
+
+      const { result, rerender } = renderHook(
+        ({ onChange }) =>
+          useControlledState<string>(undefined, "default", onChange),
+        { initialProps: { onChange: onChange1 } }
+      );
+
+      const firstSetter = result.current[1];
+
+      rerender({ onChange: onChange2 });
+      const secondSetter = result.current[1];
+
+      expect(firstSetter).not.toBe(secondSetter);
+    });
+  });
+
+  describe("Development Warnings", () => {
+    beforeEach(() => {
+      process.env.NODE_ENV = "development";
+    });
+
+    it("should warn when switching from uncontrolled to controlled", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const { rerender } = renderHook(
+        ({ value }) => useControlledState<string>(value, "default", undefined),
+        { initialProps: { value: undefined as string | undefined } }
+      );
+
+      // Switch to controlled
+      rerender({ value: "controlled" });
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("uncontrolled to controlled")
+      );
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("may cause unexpected behavior")
+      );
+    });
+
+    it("should warn when switching from controlled to uncontrolled", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const { rerender } = renderHook(
+        ({ value }) => useControlledState<string>(value, "default", undefined),
+        { initialProps: { value: "controlled" as string | undefined } }
+      );
+
+      // Switch to uncontrolled
+      rerender({ value: undefined });
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("controlled to uncontrolled")
+      );
+    });
+
+    it("should not warn when staying in the same mode", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const { rerender } = renderHook(
+        ({ value }) => useControlledState<string>(value, "default", undefined),
+        { initialProps: { value: "first" as string | undefined } }
+      );
+
+      rerender({ value: "second" });
+      rerender({ value: "third" });
+
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    // Note: Production mode test cannot be reliably tested in unit tests
+    // because isDevelopment is evaluated at module load time.
+    // In real production builds, bundlers will tree-shake the warning code entirely.
+  });
+
+  describe("Edge Cases", () => {
+    it("should handle boolean values correctly", () => {
+      const { result } = renderHook(() =>
+        useControlledState<boolean>(undefined, false, undefined)
+      );
+
+      expect(result.current[0]).toBe(false);
+
+      act(() => {
+        result.current[1](true);
+      });
+
+      expect(result.current[0]).toBe(true);
+    });
+
+    it("should handle 0 as a valid controlled value", () => {
+      const { result } = renderHook(() =>
+        useControlledState<number>(0, 100, undefined)
+      );
+
+      // 0 should be treated as controlled, not uncontrolled
+      expect(result.current[0]).toBe(0);
+    });
+
+    it("should handle empty string as controlled value", () => {
+      const { result } = renderHook(() =>
+        useControlledState<string>("", "default", undefined)
+      );
+
+      expect(result.current[0]).toBe("");
+    });
+
+    it("should handle null as controlled value", () => {
+      const { result } = renderHook(() =>
+        useControlledState<string | null>(null, "default", undefined)
+      );
+
+      expect(result.current[0]).toBe(null);
+    });
+
+    it("should not call onChange on initial render", () => {
+      const onChange = vi.fn();
+      renderHook(() =>
+        useControlledState<string>(undefined, "initial", onChange)
+      );
+
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it("should handle rapid value changes", () => {
+      const { result } = renderHook(() =>
+        useControlledState<number>(undefined, 0, undefined)
+      );
+
+      act(() => {
+        result.current[1](1);
+        result.current[1](2);
+        result.current[1](3);
+        result.current[1](4);
+        result.current[1](5);
+      });
+
+      expect(result.current[0]).toBe(5);
+    });
+  });
+});


### PR DESCRIPTION
This PR contains code changes to implementing the `useControlledState` hook.

## Changes
- Added the `useControlledState` hook in the library.
- Added Vitest unit tests for the hook.
- Added example for usage of the hook.